### PR TITLE
Update cad_mesh_dimensions.py

### DIFF
--- a/addons/cad_mesh_dimensions/cad_mesh_dimensions.py
+++ b/addons/cad_mesh_dimensions/cad_mesh_dimensions.py
@@ -460,15 +460,14 @@ def cad_mesh_dimensions_draw(self, context):
         row.prop(ob.cad_mesh_dimensions, 'orientation')
         row.label(text="", icon='BLANK1')
         row.label(text="", icon='BLANK1')
-
         orientation = transform_orientation_get(ob)
+        layout = self.layout
+        layout.use_property_split = True
+        col = layout.column()
+        row = col.row(align=True)
+        row.use_property_decorate = False
         if orientation not in ['GLOBAL', 'NORMAL']:
-            col = layout.column()
-            row = col.row(align=True)
-            row().label(text="The orientation mode '%s'" % orientation.capitalize(), icon='ERROR')
-            row().label(text="in the Blender tool settings is not")
-            row().label(text="supported, defaulting to 'Global'.")
-            row.label(text="", icon='BLANK1')
+            row.label(text="'%s' mode unsupported. Using 'Global'." % orientation.capitalize(), icon='ERROR')
     if context.mode == 'OBJECT' or context.mode == 'EDIT_MESH':
         layout = self.layout
         layout.use_property_split = True


### PR DESCRIPTION
NOTE: I'm by no means a dev, but I can often patch minor things together. I was in need of the CAD Mesh Dimensions feature in Blender, so grabbed it and felt like a few trivial changes would make it more enjoyable to use, at least for me. So I'm submitting them as a Pull Req, in case they're handy for everyone.

Added: When in object mode, the object dimensions (same as 'dimensions' in N-Panel > Item > Transform) will show, instead of being empty.
Added: When nothing is selected, dimensions read 0, 0, 0.
Added: New button to apply scale, which appears as a warning whenever object scale is not 1,1,1. This is to act as a reminder, to avoid mis-aligned dimensions between object & edit mode.
Change: Moved the panel to sit with the rest of the transform properties in the Object Properties Tab
Change: Some minor layout/UI adjustments
Change: Set the default orientation mode to 'Normal'
Fix: Applied pybin fix as mentioned here: https://github.com/EleotleCram/blender-cad-tools/issues/3